### PR TITLE
Add Registry namespace to fix PHP error

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * HTML Article View class for the Content component
  *


### PR DESCRIPTION
Missing use Joomla\Registry\Registry; at the top, creates an error after applying patch.
